### PR TITLE
bump to lastest dotnet sdk version, keyvault name now required on app templates updating docs

### DIFF
--- a/docs/AspNetCoreApiAzureNsb.md
+++ b/docs/AspNetCoreApiAzureNsb.md
@@ -22,8 +22,7 @@ See details [here](https://github.com/prospa-group/DotnetSolution)
 
 ```console
 cd src
-dotnet new prospaapiazurensb -n "MyNew.API" 
---keyvaultName {Keyvault name is required, don't include the environment prefix or use the DNS name. e.g. template-keyvault}
+dotnet new prospaapiazurensb -n "MyNew.API"
 --appDomain {Application domain name for tagging log entries}
 ```
 

--- a/docs/WorkerAzure.md
+++ b/docs/WorkerAzure.md
@@ -13,8 +13,7 @@ See details [here](https://github.com/prospa-group/DotnetSolution)
 
 ```console
 cd src
-dotnet new prospaworker -n "MyNew.Worker" 
---keyvaultName {Keyvault name is required, don't include the environment prefix or use the DNS name. e.g. template-keyvault}
+dotnet new prospaworker -n "MyNew.Worker"
 --appDomain {Application domain name for tagging log entries}
 ```
 

--- a/docs/WorkerAzureNsb.md
+++ b/docs/WorkerAzureNsb.md
@@ -15,8 +15,7 @@ See details [here](https://github.com/prospa-group/DotnetSolution)
 
 ```console
 cd src
-dotnet new prospaworkersnb -n "MyNew.Worker" 
---keyvaultName {Keyvault name is required, don't include the environment prefix or use the DNS name. e.g. template-keyvault}
+dotnet new prospaworkernsb -n "MyNew.Worker"
 --appDomain {Application domain name for tagging log entries}
 ```
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "projects": [ "src" ],
   "sdk": {
-    "version": "3.1.101",
+    "version": "3.1.300",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
- bump global.json to lastest dotnet sdk
- updating template docs, keyvault name no longer required